### PR TITLE
fix: :bug: image attribute broken by line wrap in alt-text

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -25,7 +25,5 @@ læse mere om projektets formål og kontaktpersoner.
 ::: {#listing}
 :::
 
-![](/images/visuelt-saerkende.png){fig-alt="Projektbanner med teksten
-"Spørg til årsstatus – Tarmkræftscreening som en del af
-diabetesomsorgen'. Logoer for Region Midtjylland, Steno Diabetes Center
-Aarhus og Kræftens Bekæmpelse." width="50%" fig-align="center"}
+![](/images/visuelt-saerkende.png){fig-alt="Projektbanner med teksten 'Spørg til årsstatus – Tarmkræftscreening som en del af diabetesomsorgen'. Logoer for Region Midtjylland, Steno Diabetes Center Aarhus og Kræftens Bekæmpelse."
+width="50%" fig-align="center"}


### PR DESCRIPTION
Fixing the image added in #6 which was broken by a line wrap in the alt-text.

Needs no review.  